### PR TITLE
Give the Left Drawer a Backdrop

### DIFF
--- a/frontend/bundles/index.tsx
+++ b/frontend/bundles/index.tsx
@@ -2,9 +2,7 @@ import { AuthProvider } from '../src/hooks/useAuth'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from '../src/App'
-import reportWebVitals from '../src/reportWebVitals'
 import { BrowserRouter } from 'react-router-dom'
-
 import { ApolloProvider } from "@apollo/client";
 import { useAuthenticatedApolloClient } from "../src/hooks/useAuthenticatedApolloClient";
 import { Provider } from 'react-redux'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,18 +10,15 @@ import { ResetPage } from './containers/ResetPage';
 import { Tournaments } from './containers/TournamentPage';
 import { Divisions } from './containers/DivisionPage';
 import { TDEditor } from './containers/TDEditor';
-
 import React from 'react';
 import './App.css';
 import { Home } from './containers/Home';
 import { Todos } from './containers/Todo';
 import { Files } from './containers/Files';
 import { Route, useNavigate, Routes } from 'react-router-dom';
-
 import '@mui/material/colors';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button'
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
@@ -31,10 +28,9 @@ import MenuIcon from '@mui/icons-material/Menu';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
-import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled';
 import { ChevronLeft, Inbox, Mail, AccountCircle } from '@mui/icons-material';
-import { Breadcrumbs, Divider, Link, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import { Backdrop, Divider, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { RoundsInProgress } from './containers/RoundsInProgress';
@@ -117,106 +113,112 @@ const App = () => {
           </AppBar>
 
         </Box>
-        <Drawer
-          sx={{
-            width: drawerWidth,
-            flexShrink: 0,
-            '& .MuiDrawer-paper': {
-              width: drawerWidth,
-              boxSizing: 'border-box',
-            },
-          }}
-          variant="persistent"
-          anchor="left"
+        <Backdrop
+          onClick={handleDrawerClose}
           open={open}
+          sx={{ zIndex: 1 }}
         >
-          <DrawerHeader>
-            <IconButton onClick={handleDrawerClose}>
-              <ChevronLeft />
-            </IconButton>
-          </DrawerHeader>
-          <Divider />
-          <List>
-            {['Tournament', 'Division', 'Room', 'Round'].map((text, index) => (
-              <ListItem key={text} disablePadding
-                onClick={() => {
-                  switch (index % 4) {
-                    case 0:
-                      navigate("/tournament");
-                      break;
-                    case 1:
-                      navigate("/division");
-                      break;
-                    case 2:
-                      alert("room");
-                      break;
-                    case 3:
-                      alert('round');
-                  }
-                }}>
-                <ListItemButton>
-                  <ListItemIcon>
-                    {index % 2 === 0 ? <Inbox /> : <Mail />}
-                  </ListItemIcon>
-                  <ListItemText primary={text} />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
-          <Divider />
-          <List>
-            {['Quizzes', 'Team', 'Individual'].map((text, index) => (
-              <ListItem key={text} disablePadding
-                onClick={() => {
-                  switch (index % 3) {
-                    case 0:
-                      alert("quizzes");
-                      break;
-                    case 1:
-                      alert("team");
-                      break;
-                    case 2:
-                      alert("individual");
-                      break;
-                  }
-                }}>
-                <ListItemButton>
-                  <ListItemIcon>
-                    {index % 2 === 0 ? <Inbox /> : <Mail />}
-                  </ListItemIcon>
-                  <ListItemText primary={text} />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
-          <Divider />
-          <List>
-            {['Todos', 'Files', 'GraphQL'].map((text, index) => (
-              <ListItem key={text} disablePadding
-                onClick={() => {
-                  switch (index % 3) {
-                    case 0:
-                      navigate("/todos");
-                      break;
-                    case 1:
-                      navigate("/files");
-                      break;
-                    case 2:
-                      navigate("/gql");
-                      break;
-                  }
-                }}
-              >
-                <ListItemButton>
-                  <ListItemIcon>
-                    {index % 2 === 0 ? <Inbox /> : <Mail />}
-                  </ListItemIcon>
-                  <ListItemText primary={text} />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
-        </Drawer>
+          <Drawer
+            sx={{
+              width: drawerWidth,
+              flexShrink: 0,
+              '& .MuiDrawer-paper': {
+                width: drawerWidth,
+                boxSizing: 'border-box',
+              },
+            }}
+            variant="persistent"
+            anchor="left"
+            open={open}
+          >
+            <DrawerHeader>
+              <IconButton onClick={handleDrawerClose}>
+                <ChevronLeft />
+              </IconButton>
+            </DrawerHeader>
+            <Divider />
+            <List>
+              {['Tournament', 'Division', 'Room', 'Round'].map((text, index) => (
+                <ListItem key={text} disablePadding
+                  onClick={() => {
+                    switch (index % 4) {
+                      case 0:
+                        navigate("/tournament");
+                        break;
+                      case 1:
+                        navigate("/division");
+                        break;
+                      case 2:
+                        alert("room");
+                        break;
+                      case 3:
+                        alert('round');
+                    }
+                  }}>
+                  <ListItemButton>
+                    <ListItemIcon>
+                      {index % 2 === 0 ? <Inbox /> : <Mail />}
+                    </ListItemIcon>
+                    <ListItemText primary={text} />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+            <Divider />
+            <List>
+              {['Quizzes', 'Team', 'Individual'].map((text, index) => (
+                <ListItem key={text} disablePadding
+                  onClick={() => {
+                    switch (index % 3) {
+                      case 0:
+                        alert("quizzes");
+                        break;
+                      case 1:
+                        alert("team");
+                        break;
+                      case 2:
+                        alert("individual");
+                        break;
+                    }
+                  }}>
+                  <ListItemButton>
+                    <ListItemIcon>
+                      {index % 2 === 0 ? <Inbox /> : <Mail />}
+                    </ListItemIcon>
+                    <ListItemText primary={text} />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+            <Divider />
+            <List>
+              {['Todos', 'Files', 'GraphQL'].map((text, index) => (
+                <ListItem key={text} disablePadding
+                  onClick={() => {
+                    switch (index % 3) {
+                      case 0:
+                        navigate("/todos");
+                        break;
+                      case 1:
+                        navigate("/files");
+                        break;
+                      case 2:
+                        navigate("/gql");
+                        break;
+                    }
+                  }}
+                >
+                  <ListItemButton>
+                    <ListItemIcon>
+                      {index % 2 === 0 ? <Inbox /> : <Mail />}
+                    </ListItemIcon>
+                    <ListItemText primary={text} />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+          </Drawer>
+        </Backdrop>
         <div style={{ margin: '0 auto', maxWidth: '1200px' }}>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/frontend/src/containers/Home.tsx
+++ b/frontend/src/containers/Home.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { createTheme, styled } from '@mui/material/styles'
-import { makeStyles } from '@mui/styles'
 import Card from "@mui/material/Card"
 import CardHeader from '@mui/material/CardHeader'
 import CardMedia from "@mui/material/CardMedia"
@@ -10,7 +9,6 @@ import Typography from '@mui/material/Typography'
 import Box from '@mui/material/Box'
 import Avatar from '@mui/material/Avatar'
 import IconButton, { IconButtonProps } from '@mui/material/IconButton'
-import Fab from '@mui/material/Fab'
 import AddIcon from "@mui/icons-material/Add"
 import { red } from '@mui/material/colors'
 import FavoriteIcon from '@mui/icons-material/Favorite'
@@ -19,18 +17,15 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import CardActions from '@mui/material/CardActions'
 import Collapse from '@mui/material/Collapse'
 import { TournamentAPI } from './TournamentPage'
-import { Route, useNavigate, Routes, Form } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
 import SettingsIcon from '@mui/icons-material/Settings';
-import { selectDisplayDate, selectTournament, setDisplayDate, setTournament, toggleIsOn, setTid } from '../breadcrumb'
+import { setDisplayDate, setTournament, setTid } from '../breadcrumb'
 import { useAppSelector, useAppDispatch } from '../app/hooks';
 import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid'
-import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
-import Select, { SelectChangeEvent } from '@mui/material/Select'
+import Select from '@mui/material/Select'
 import InputLabel from '@mui/material/InputLabel'
-import FormControl from '@mui/material/FormControl'
 import TextField from '@mui/material/TextField'
 import { Dayjs } from 'dayjs'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
@@ -43,12 +38,9 @@ import CloseIcon from '@mui/icons-material/Close'
 import Slide from '@mui/material/Slide'
 import { TransitionProps } from '@mui/material/transitions'
 import Button from '@mui/material/Button';
-import ListItemText from '@mui/material/ListItemText';
 import ListItem from '@mui/material/ListItem'
 import List from '@mui/material/List';
-import Divider from '@mui/material/Divider';
 import TextareaAutosize from '@mui/material/TextareaAutosize';
-import { Code } from '@mui/icons-material'
 import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 import Tooltip from '@mui/material/Tooltip';
@@ -122,9 +114,25 @@ export const Home = () => {
     // the API to not worry abut page size and page.  This is more date based.
     <div >
       <Tooltip title="Add a new tournament" arrow>
-        <Fab color="primary" onClick={() => handleTournamentEditorClickOpen()} aria-label="Add Tournament">
+        <Button
+          aria-label="Add Tournament"
+          color="primary"
+          onClick={() => handleTournamentEditorClickOpen()}
+          sx={{
+            backgroundColor: "#008080",
+            borderRadius: "50%",
+            color: "#fff",
+            height: 56,
+            minWidth: "unset",
+            width: 56,
+            "&:hover": {
+              backgroundColor: "rgb(0, 89, 89)",
+              boxShadow: "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)"
+            }
+          }}
+        >
           <AddIcon />
-        </Fab>
+        </Button>
       </Tooltip>
       <div className="Form">
         <div style={{ display: 'flex' }}>

--- a/frontend/src/setupDevelopment.tsx
+++ b/frontend/src/setupDevelopment.tsx
@@ -5,7 +5,7 @@
 /* require() this file in development mode to enable development hints */
 
 import React, { useEffect, useRef, useState } from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import {
   QueryClient,
   QueryClientProvider,
@@ -316,13 +316,13 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
 
-ReactDOM.render (
+const root = createRoot(devBox.children[1])
+root.render (
   <>
     <QueryClientProvider client={queryClient}>
       <DevBox />
     </QueryClientProvider>
-  </>,
-  devBox.children[1]
+  </>
 )
 
 export {}

--- a/getrustdev
+++ b/getrustdev
@@ -12,17 +12,17 @@ sudo apt install cargo
 # This is required before running `cargo build` on the create-rust-app project.
 sudo apt install pkg-config
 
-# This is required before running `cargo build` on the qview project.
-sudo apt install libpq-dev
-
 # Install the database library.
 sudo apt install postgresql
 sudo apt install postgresql-contrib
 
+# Install the database driver for PostgreSQL.
+sudo apt install libpq-dev
+
 #
 # Install a tool for helping manipulate Diesel (Rust CRUD ORM)
 #
-cargo install diesel_cli
+cargo install diesel_cli --no-default-features --features postgres
 #
 # actix-web (Rust Web Server) stuff (mostly creating react web apps)
 #


### PR DESCRIPTION
This branch is the result of me looking for things to work on, so these changes might not be wanted. Change list:
- Removed unused imports
- Placed a `Backdrop` behind the `Drawer` component (which will be easier to review if whitespace changes are hidden)
- Replaced a `Fab` component with `Button` component, but with some styles from the `Fab` component. The `Fab` component seems to be designed to be always visible, which doesn't work well with the `Backdrop` component. (https://mui.com/material-ui/react-floating-action-button/)
- Replaced `ReactDOM.render()` with `createRoot()` because the browser console was showing a message that React was going to behave as if it were React 17 even though React 18 is specified, until this was changed.
- Changed `getrustdev` to better explain why `libpq-dev` is needed. I did this after trying to run the latest Diesel script that you added to the readme and the command line didn't recognize the name `diesel` so I reinstalled it, but not before finding the flag `--features postgres` which can limit the Diesel features to those needed for Postgres, so I put that flag in and the related flag which makes it work.