### PR TITLE
Refine the ConfirmDialog Component

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,36 +1,44 @@
-// ConfirmDialog.tsx  - material ui
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogContent from '@mui/material/DialogContent';
-import DialogActions from '@mui/material/DialogActions';
-import Button from '@mui/material/Button';
+import CloseIcon from '@mui/icons-material/Close';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
-import CloseIcon from '@mui/material/IconButton';
+import React from 'react';
 
-const ConfirmDialog = (message: String) => {
-    return (
-        <Dialog open={true} maxWidth="sm" fullWidth>
-            <DialogTitle>Confirm the action</DialogTitle>
-            <Box position="absolute" top={0} right={0}>
-                <IconButton>
-                    <CloseIcon />
-                </IconButton>
-            </Box>
-            <DialogContent>
-                <Typography>{message}</Typography>
-            </DialogContent>
-            <DialogActions>
-                <Button color="primary" variant="contained">
-                    Cancel
-                </Button>
-                <Button color="secondary" variant="contained">
-                    Confirm
-                </Button>
-            </DialogActions>
-        </Dialog>
-    );
+interface Props {
+  message: string;
+  onCancel: React.MouseEventHandler<HTMLButtonElement>;
+  onConfirm: React.MouseEventHandler<HTMLButtonElement>;
+  title: string;
+}
+
+/**
+ * This renders a confirmation dialog to confirm an action.
+ */
+export const ConfirmDialog = (props: Props) => {
+  return (
+    <Dialog open={true} maxWidth="sm" fullWidth>
+      <DialogTitle>{props.title}</DialogTitle>
+      <Box position="absolute" top={0} right={0}>
+        <IconButton aria-label="Close">
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <DialogContent>
+        <Typography>{props.message}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button color="primary" onClick={props.onCancel} variant="contained">
+          Cancel
+        </Button>
+        <Button color="secondary" onClick={props.onConfirm} variant="contained">
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
 };
-
-export default ConfirmDialog;


### PR DESCRIPTION
This branch includes all the changes I discussed on [issue #27](https://github.com/bnicholson/QView/issues/27). The diff works a lot better if whitespace changes are hidden.

Now that I think about it we'll also need to pass a prop to give to the `open` prop on the MUI `Dialog` component, but I don't have my development environment open at this moment.