### PR TITLE
Improve Tournament Cards Styling

### DIFF
--- a/frontend/src/features/TournamentCardContent.css
+++ b/frontend/src/features/TournamentCardContent.css
@@ -1,3 +1,7 @@
+.tournamentCardContent {
+  text-align: left;
+}
+
 .tournamentCardContent p,
 .tournamentCardContent h3 {
   display: flex;

--- a/frontend/src/features/TournamentCardContent.css
+++ b/frontend/src/features/TournamentCardContent.css
@@ -1,0 +1,34 @@
+.tournamentCardContent p,
+.tournamentCardContent h3 {
+  display: flex;
+  flex-direction: column;
+  line-height: 1;
+}
+
+.tournamentCardContent p:first-child,
+.tournamentCardContent h3:first-child {
+  margin-top: 0px;
+}
+
+.tournamentCardContent h3 span.dates {
+  font-size: 12px;
+  font-weight: normal;
+}
+
+.tournamentCardContent p:last-child {
+  margin-bottom: 0px;
+}
+
+.tournamentCardContent p {
+  font-size: 14px;
+}
+
+.tournamentCardContent h3 {
+  font-size: 16px;
+}
+
+.tournamentCardContent p .descriptionTitle {
+  color: gray;
+  font-size: 12px;
+  font-weight: normal;
+}

--- a/frontend/src/features/TournamentCardContent.tsx
+++ b/frontend/src/features/TournamentCardContent.tsx
@@ -1,0 +1,52 @@
+import { CardContent, CardContentProps } from "@mui/material";
+import "./TournamentCardContent.css";
+
+interface Props extends CardContentProps {
+  tournament: Pick<Tournament, "tname" | "fromdate" | "todate" | "venue" | "shortinfo" | "city" | "region" | "country" | "organization">;
+}
+
+/**
+ * This displays a tournament, presenting only details likely to be helpful for finding a tournament.
+ */
+export const TournamentCardContent = (props: Props) => {
+  const { className, tournament, ...cardContentProps } = props;
+  return (
+    <CardContent className={`tournamentCardContent${className ? ` ${className}` : ""}`} {...cardContentProps}>
+      {(tournament.tname || tournament.fromdate || tournament.todate) && (
+        <h3>
+          <span>{tournament.tname}</span>
+          <span className="dates">{`${tournament.fromdate} - ${tournament.todate}`}</span>
+        </h3>
+      )}
+      {tournament.venue && (
+        <p>
+          <span className="descriptionTitle">Venue</span><br />
+          <span>{tournament.venue}</span>
+        </p>
+      )}
+      {tournament.shortinfo && (
+        <p>
+          <span className="descriptionTitle">Info</span>
+          <span>{tournament.shortinfo}</span>
+        </p>
+      )}
+      {(tournament.country || tournament.region || tournament.city) && (
+        <p>
+          <span className="descriptionTitle">Location</span>
+          <span>
+            {tournament.city}
+            {tournament.city && tournament.region && ", "}
+            {tournament.region}
+          </span>
+          <span>{tournament.country}</span>
+        </p>
+      )}
+      {tournament.organization && (  
+        <p>
+          <span className="descriptionTitle">Organization</span>
+          <span>{tournament.organization}</span>
+        </p>
+      )}
+    </CardContent>
+  );
+};

--- a/frontend/src/features/TournamentEditorDialog.tsx
+++ b/frontend/src/features/TournamentEditorDialog.tsx
@@ -84,6 +84,7 @@ export const TournamentEditorDialog = (props: Props) => {
       setConfirmDialog(confirmDialogDefaultState);
       fromDateRef.current = initialTournament ? initialTournament.fromdate : null;
       toDateRef.current = initialTournament ? initialTournament.todate : null;
+      setErrorMsg("Simple error message");
     }
   }, [confirmDialog.isOpen, isOpen]);
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, FormControl, InputLabel, MenuItem, Select, TextField } from '@mui/material';
+import { Button, Card, CardActions, CardContent, FormControl, InputLabel, MenuItem, Select, TextField } from '@mui/material';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs, { Dayjs } from 'dayjs';
@@ -6,6 +6,7 @@ import React from 'react'
 import { TournamentAPI } from '../containers/TournamentPage';
 import { makeCancelable } from '../features/makeCancelable';
 import { states } from '../features/states';
+import { TournamentCardContent } from '../features/TournamentCardContent';
 import { TournamentEditorDialog } from '../features/TournamentEditorDialog';
 
 interface Props {
@@ -20,6 +21,7 @@ export const Home = (props: Props) => {
   const [isLoading, setIsLoading] = React.useState<boolean>(false)
   const [tournaments, setTournaments] = React.useState<Tournament[]>([])
   const [tournamentEditor, setTournamentEditor] = React.useState<{ isOpen: boolean, tournament: Tournament | undefined }>({ isOpen: false, tournament: undefined });
+  const isUserAdmin = true;
   React.useEffect(() => {
     setIsLoading(true)
     const startMillis = startDate ? startDate.valueOf() : 0;
@@ -123,27 +125,33 @@ export const Home = (props: Props) => {
         </div>
         <div style={{
           display: "flex",
-          flexWrap: "wrap"
+          flexWrap: "wrap",
+          gap: 10,
         }}>
-          <Card onClick={() => setTournamentEditor({ isOpen: true, tournament: undefined })}>
-            <CardContent>
-              Click to create a new tournament.
-            </CardContent>
-          </Card>
+          {isUserAdmin && (
+            <Card onClick={() => setTournamentEditor({ isOpen: true, tournament: undefined })}>
+              <CardContent>
+                Click to create a new tournament.
+              </CardContent>
+            </Card>
+          )}
           {isLoading ? (
             "Loading tournaments..."
           ) : (
             tournaments.map(tournament => (
               <Card key={tournament.tid} onClick={() => setTournamentEditor({ isOpen: true, tournament })}>
-                <CardContent>
-                  {`Organization: ${tournament.organization}`}
-                  <br />
-                  {`Venue: ${tournament.venue}`}
-                  <br />
-                  {`Location: ${tournament.city}, ${tournament.region}, ${tournament.country}`}
-                  <br />
-                  {`ShortInfo: ${tournament.shortinfo}`}
-                </CardContent>
+                <TournamentCardContent
+                  sx={{
+                    textAlign: "left",
+                  }}
+                  tournament={tournament}
+                />
+                <div />
+                {isUserAdmin && (
+                  <CardActions sx={{ justifyContent: "flex-end" }}>
+                    <Button size="small">Edit</Button>
+                  </CardActions>
+                )}
               </Card>
             ))
           )}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -152,12 +152,7 @@ export const Home = (props: Props) => {
           ) : (
             tournaments.map(tournament => (
               <Card key={tournament.tid} onClick={() => setTournamentEditor({ isOpen: true, tournament })}>
-                <TournamentCardContent
-                  sx={{
-                    textAlign: "left",
-                  }}
-                  tournament={tournament}
-                />
+                <TournamentCardContent tournament={tournament} />
                 {isUserAdmin && (
                   <CardActions sx={{ justifyContent: "flex-end" }}>
                     <Button size="small">Edit</Button>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,5 @@
-import { Button, Card, CardActions, CardContent, FormControl, InputLabel, MenuItem, Select, TextField } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import { Button, Card, CardActions, CardContent, FormControl, IconButton, InputLabel, MenuItem, Select, TextField } from '@mui/material';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs, { Dayjs } from 'dayjs';
@@ -126,12 +127,23 @@ export const Home = (props: Props) => {
         <div style={{
           display: "flex",
           flexWrap: "wrap",
-          gap: 10,
+          gap: 10
         }}>
           {isUserAdmin && (
             <Card onClick={() => setTournamentEditor({ isOpen: true, tournament: undefined })}>
-              <CardContent>
-                Click to create a new tournament.
+              <CardContent sx={{ alignItems: "center", display: "flex", flexDirection: "column", height: "100%", justifyContent: "center" }}>
+                <div style={{
+                  alignItems: "center",
+                  background: "#e5e5e5",
+                  borderRadius: 40,
+                  display: "flex",
+                  height: 80,
+                  justifyContent: "center",
+                  width: 80
+                }}>
+                  <AddIcon fontSize="large" />
+                </div>
+                Create a New Tournament
               </CardContent>
             </Card>
           )}
@@ -146,7 +158,6 @@ export const Home = (props: Props) => {
                   }}
                   tournament={tournament}
                 />
-                <div />
                 {isUserAdmin && (
                   <CardActions sx={{ justifyContent: "flex-end" }}>
                     <Button size="small">Edit</Button>


### PR DESCRIPTION
# Description
The tournament cards on the new home page were barely implemented. This branch greatly improves their styling. With this change, the only major issue I see left with the new home page is setting the correct behavior when the cards are clicked. (The correct behavior: if a card is clicked, it should open that tournament not the editor. The edit button on each card should open the editor. Also there's a bug with the date pickers in the new tournament editor component.)

The _Create a Tournament_ and _Edit_ buttons should only appear for admin users, although I don't think the app has the ability to differentiate at this time.

# Screenshot
![image](https://user-images.githubusercontent.com/8635640/209713995-688a06ec-4884-40b0-9b69-7eb7a65c6e0d.png)
