### PR TITLE
Open the Tournament View Instead of Editor

### DIFF
--- a/frontend/src/features/TournamentCardContent.css
+++ b/frontend/src/features/TournamentCardContent.css
@@ -1,4 +1,5 @@
 .tournamentCardContent {
+  cursor: pointer;
   text-align: left;
 }
 

--- a/frontend/src/features/TournamentEditorDialog.tsx
+++ b/frontend/src/features/TournamentEditorDialog.tsx
@@ -77,16 +77,14 @@ export const TournamentEditorDialog = (props: Props) => {
   const [errormsg, setErrorMsg] = React.useState<string>("Simple error message");
   const [confirmDialog, setConfirmDialog] = React.useState(confirmDialogDefaultState);
 
-  // If the tournament editor is closed, reset the state.
-  React.useEffect(() => {
-    if (!isOpen && confirmDialog.isOpen) {
-      setTournament(tournamentEmptyState);
-      setConfirmDialog(confirmDialogDefaultState);
-      fromDateRef.current = initialTournament ? initialTournament.fromdate : null;
-      toDateRef.current = initialTournament ? initialTournament.todate : null;
-      setErrorMsg("Simple error message");
-    }
-  }, [confirmDialog.isOpen, isOpen]);
+  /** Call this whenever the tournament editor is closed. */
+  const resetState = () => {
+    setTournament(tournamentEmptyState);
+    setConfirmDialog(confirmDialogDefaultState);
+    fromDateRef.current = initialTournament ? initialTournament.fromdate : null;
+    toDateRef.current = initialTournament ? initialTournament.todate : null;
+    setErrorMsg("Simple error message");
+  };
 
   // If the initial tournament changes, set or clear the initial fields.
   React.useEffect(() => {
@@ -101,13 +99,20 @@ export const TournamentEditorDialog = (props: Props) => {
     }
   }, [initialTournament])
 
-  const openCancelDialog = () => setConfirmDialog({
-    isOpen: true,
-    message: "Any changes you've made to the tournament will be lost.",
-    handleCancel: () => setConfirmDialog(confirmDialogDefaultState),
-    handleConfirm: () => onCancel(),
-    title: "Are you sure you want to cancel tournament edit?"
-  });
+  const openCancelDialog = () => {
+    if (tournament == initialTournament || tournament == tournamentEmptyState) {
+      onCancel();
+      resetState();
+    } else {
+      setConfirmDialog({
+        isOpen: true,
+        message: "Any changes you've made to the tournament will be lost.",
+        handleCancel: () => setConfirmDialog(confirmDialogDefaultState),
+        handleConfirm: () => { onCancel(); resetState(); },
+        title: "Are you sure you want to cancel tournament edit?"
+      })
+    }
+  };
 
   const handleTournamentEditorSave = async () => {
     if (!fromDateRef.current || !toDateRef.current || fromDateRef.current.isAfter(toDateRef.current)) {
@@ -161,7 +166,7 @@ export const TournamentEditorDialog = (props: Props) => {
     isOpen: true,
     message: "Cancel if you want to make more changes.",
     handleCancel: () => setConfirmDialog(confirmDialogDefaultState),
-    handleConfirm: () => handleTournamentEditorSave(),
+    handleConfirm: () => { handleTournamentEditorSave(); resetState(); },
     title: "Save changes to the tournament?"
   });
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,6 +4,9 @@ import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs, { Dayjs } from 'dayjs';
 import React from 'react'
+import { useNavigate } from 'react-router-dom';
+import { useAppDispatch } from '../app/hooks';
+import { setTid, setTournament } from '../breadcrumb';
 import { TournamentAPI } from '../containers/TournamentPage';
 import { makeCancelable } from '../features/makeCancelable';
 import { states } from '../features/states';
@@ -23,6 +26,14 @@ export const Home = (props: Props) => {
   const [tournaments, setTournaments] = React.useState<Tournament[]>([])
   const [tournamentEditor, setTournamentEditor] = React.useState<{ isOpen: boolean, tournament: Tournament | undefined }>({ isOpen: false, tournament: undefined });
   const isUserAdmin = true;
+  const dispatcher = useAppDispatch();
+  const navigate = useNavigate();
+  const openTournament = (tournament: Tournament) => {
+    dispatcher(setTournament(tournament.tname));
+    dispatcher(setTid(tournament.tid));
+    navigate("/division");
+  }
+  const closeTournamentEditor = () => setTournamentEditor({ isOpen: false, tournament: undefined });
   React.useEffect(() => {
     setIsLoading(true)
     const startMillis = startDate ? startDate.valueOf() : 0;
@@ -151,11 +162,13 @@ export const Home = (props: Props) => {
             "Loading tournaments..."
           ) : (
             tournaments.map(tournament => (
-              <Card key={tournament.tid} onClick={() => setTournamentEditor({ isOpen: true, tournament })}>
-                <TournamentCardContent tournament={tournament} />
+              <Card key={tournament.tid}>
+                <TournamentCardContent onClick={() => openTournament(tournament)} tournament={tournament} />
                 {isUserAdmin && (
                   <CardActions sx={{ justifyContent: "flex-end" }}>
-                    <Button size="small">Edit</Button>
+                    <Button onClick={() => setTournamentEditor({ isOpen: true, tournament })} size="small">
+                      Edit
+                    </Button>
                   </CardActions>
                 )}
               </Card>
@@ -166,8 +179,8 @@ export const Home = (props: Props) => {
       <TournamentEditorDialog
         initialTournament={tournamentEditor.tournament}
         isOpen={tournamentEditor.isOpen}
-        onCancel={() => setTournamentEditor({ isOpen: false, tournament: undefined })}
-        onSave={tournament => setTournaments(tournaments => tournaments.concat([tournament]))}
+        onCancel={closeTournamentEditor}
+        onSave={tournament => { closeTournamentEditor; setTournaments(tournaments => tournaments.concat([tournament])); }}
       />
     </div>
   )


### PR DESCRIPTION
# Description
- When tournament details are clicked, open that tournament instead of opening the editor for the tournament.
- Use the _Edit_ button to edit the tournament.
- Show a pointer cursor when hovering over the tournament details.
- If a tournament wasn't changed, don't ask for confirmation before canceling an edit.

# What's Next?
- Fix the date pickers so they don't appear to clear when saving a tournament.
- In the OG home page, editing an existing tournament opens in a new route. In this version it opens in a dialog. What is preferred?
- Verify that no other functionality is missing.
- Replace the OG home page with the new one.